### PR TITLE
conditionally avoid -pgmlg++ on darwin

### DIFF
--- a/cryptol-verifier.cabal
+++ b/cryptol-verifier.cabal
@@ -70,5 +70,7 @@ executable css
 
   hs-source-dirs : css
   main-is : Main.hs
-  GHC-options: -Wall -O2 -rtsopts -pgmlg++
+  GHC-options: -Wall -O2 -rtsopts
+  if !os(darwin)
+    GHC-options: -pgmlg++
   extra-libraries:      stdc++


### PR DESCRIPTION
It appears that the flag `pgmlg++` was added so as to use g++ for
linking the `css` executable.  Unfortunately, on darwin, command-line
arguments such as `-no-pie` and `-stdlib=libc++` are passed to `g++`,
which is believed to be `clang++`.  Those flags trigger a warning in the
compilation phase, but also trigger an error in the linker phase, when
passed to the real `g++`.

This proposed change conditionally ignores this option.  I'm not sure
whether it is safe to do so, and what are the consequences, but the
executable `css` builds, and at least can be run with no input on
Darwin.  Not knowing the intent of the original flag, I cannot vouch
for whether this retains the expected functionality.

@atomb Do you remember what this flag achieved? Do you know whether this proposed change is ill-advised or okay?

Thanks!