### PR TITLE
Add a `parmap` implementation to `cryptol-verifier`

### DIFF
--- a/saw/Cryptol.sawcore
+++ b/saw/Cryptol.sawcore
@@ -221,6 +221,20 @@ Rational = #();
 ecRatio : Integer -> Integer -> Rational;
 ecRatio x y = ();
 
+
+--------------------------------------------------------------------------------
+-- Parmap (Experimental)
+--
+-- This is implemented here as a bog-standard sequential `map`
+
+-- parmap : {a, b, n} (fin n) => (a -> b) -> [n]a -> [n]b
+ecParmap : (a:sort 0) -> (b:sort 0) -> (n: Num) -> (a -> b) -> seq n a -> seq n b;
+ecParmap a b n =
+  Num#rec (\ (n:Num) -> (a -> b) -> seq n a -> seq n b)
+    ( \ (n:Nat) -> \ (f: a -> b) -> \ (xs: Vec n a) -> map a b f n xs )
+    ( \ (f: a -> b) -> \ (xs:Stream a) -> error (Stream b) "Unexpected infinite stream in parmap" )
+    n;
+
 --------------------------------------------------------------------------------
 -- Type coercions
 

--- a/src/Verifier/SAW/Cryptol.hs
+++ b/src/Verifier/SAW/Cryptol.hs
@@ -668,6 +668,9 @@ prelPrims =
     --                            --              , first != next
     --                            --              , lengthFromThenTo first next last == len) => [len]a
 
+    -- Experimental: parmap
+  , ("parmap",       flip scGlobalDef "Cryptol.ecParmap")      -- {a, b, n} (fin n) => (a -> b) -> [n]a -> [n]b
+
   , ("error",        flip scGlobalDef "Cryptol.ecError")       -- {at,len} (fin len) => [len][8] -> at -- Run-time error
   , ("random",       flip scGlobalDef "Cryptol.ecRandom")      -- {a} => [32] -> a -- Random values
   , ("trace",        flip scGlobalDef "Cryptol.ecTrace")       -- {n,a,b} [n][8] -> a -> b -> b


### PR DESCRIPTION
It simply does a standard sequential `map` on Vectors.